### PR TITLE
Wrong Link to your weekly blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ footer-links:
 # It should be "/USER_NAME-weekly" in which USER_NAME is replaced by your actual
 # user name for GitHub.
 
-url: "https://nyu-ossd-s20.github.io/weekly"
+url: "https://nyu-ossd-s20.github.io/MuyingLi-weekly"
 
 # CUSTOMIZE
 # Replace this with the name of your own repository.


### PR DESCRIPTION
I fixed a link in the -config.yml that was supposed to link to you weekly blog but pointed to the class github.